### PR TITLE
fix error for github pages deployment

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,6 +8,6 @@
     {{ else }}
         <link rel="icon" type="image/x-icon" href="{{ relURL "favicon.ico"}}">
     {{ end }}
-    <link rel="stylesheet" href="{{ "/css/styles.css" | relURL }}">
+    <link rel="stylesheet" href="{{ "css/styles.css" | relURL }}">
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </head>


### PR DESCRIPTION
By using `/css/` the relative link was not parsed, by making the theme useless for github pages deployments. I have just remove the absolute path, by fixing the issue.
